### PR TITLE
Fix/Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,19 +17,17 @@ Screendump
 Installation
 ----
 ```
-$root: cp -r ./dm-refind-theme /boot/EFI/refind-theme
-$root: vim /boot/EFI/refind.conf
+# Create the theme folder in /boot/EFI/refind if it doesn't exist. Be sure that the folder refind is in /boot/EFI; if not, find it and replace the path with yours in the following commands.
+$root: mkdir /boot/EFI/refind/themes
+#Copy the folder
+$root: cp -r ./dm-refind-theme /boot/EFI/refind/themes/
 ``` 
 
-Change the following options:
+Add this line at the end of /boot/EFI/refind/refind.conf:
 ```
-hideui singleuser,arrows,hints,badges,label
-icons_dir dm-refind-theme/icons
-banner dm-refind-theme/background.png
-selection_big dm-refind-theme/selection_big.png
-selection_small dm-refind-theme/selection_small.png
-
+include themes/dm-refind-theme/theme.conf
 ```
+and comment other `include <theme.conf>` lines with a `#`.
 
 Attributions
 ----

--- a/theme.conf
+++ b/theme.conf
@@ -1,0 +1,6 @@
+hideui singleuser,arrows,hints,badges,label
+icons_dir themes/dm-refind-theme/icons
+banner themes/dm-refind-theme/background.png
+selection_big themes/dm-refind-theme/selection-big.png
+selection_small themes/dm-refind-theme/selection-small.png
+showtools shutdown, reboot


### PR DESCRIPTION
I added a config file to be included in refind.conf (instead of adding the options manually). I specify in the config file to display only the reboot and shutdown icons. My version must be installed in refind/themes.